### PR TITLE
Take sizeMapping prop, which is fed into a SizeMappingBuilder

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -88,7 +88,20 @@ export default (
       <p>No cum omnis epicurei, an elitr ludus qualisque cum. Ludus alienum iudicabit id qui. Convenire incorrupte
        reprehendunt id eum. Solum clita quo id. Nisl sale inimicus ea sea, per quem timeam tamquam ad. blah</p>
     </div>
-    <AdPanel adTag="/5605/teg.fmsq/wdif/busi" sizes={[ [ 300, 250 ] ]} reserveHeight={250} />
+    <AdPanel adTag="/5605/teg.fmsq/wdif/busi"
+    sizes={[ [ 300, 250 ] ]}
+    targeting={
+      [
+        [ 'pos', 'something' ],
+        [ 'other_key', 'something_else' ],
+      ]
+    }
+    sizeMapping={
+      [
+        [ [ 1024, 768 ], [ [ 300, 250 ] ] ],
+      ]
+    }
+    reserveHeight={250} />
     <div>
       <p>Lorem ipsum dolor sit amet, sit quod odio intellegebat no. Causae labitur sadipscing ne eos, vis tota eirmod
        debitis ex. Sit ubique nominavi erroribus in, stet lorem tation ea pri. Ut movet gubergren est, quo euismod

--- a/index.es6
+++ b/index.es6
@@ -12,6 +12,7 @@ export default class AdPanel extends React.Component {
       lazyLoad: React.PropTypes.bool,
       lazyLoadMargin: React.PropTypes.number,
       sizes: React.PropTypes.arrayOf(React.PropTypes.array),
+      sizeMapping: React.PropTypes.arrayOf(React.PropTypes.array),
       reserveHeight: React.PropTypes.number,
       styled: React.PropTypes.bool,
     };
@@ -23,6 +24,10 @@ export default class AdPanel extends React.Component {
       lazyLoad: true,
       lazyLoadMargin: 350,
       sizes: [ [ 60, 60 ], [ 70, 70 ], [ 300, 250 ], [ 1024, 768 ] ],
+      sizeMapping: [
+        [[980, 200], [[1024, 768]]],
+        [[0, 0], [[300, 250]]],
+      ],
       styled: true,
     };
   }
@@ -91,24 +96,27 @@ export default class AdPanel extends React.Component {
     window.removeEventListener('resize', this.loadElementWhenInView);
   }
 
+  buildSizeMapping() {
+    let mapping = this.props.sizeMapping || [];
+    const sizeMappingBuilder = window.googletag.sizeMapping();
+    return mapping.reduce((builder, [viewportSize, adSizes]) => {
+      return builder.addSize(viewportSize, adSizes)
+    }, sizeMappingBuilder).build();
+  }
+
   generateAd() {
     this.setState({ adGenerated: true });
     if ((window.googletag) && (this.props.adTag)) {
       const googleTag = window.googletag;
       googleTag.cmd.push(() => {
-        const mappingAd = window.googletag.sizeMapping()
-          .addSize([ 980, 200 ], [ 1024, 768 ])
-          .addSize([ 0, 0 ], [ 300, 250 ])
-          .build();
+        const sizeMapping = this.buildSizeMapping();
         const slot = googleTag.defineSlot(
           this.props.adTag,
           this.props.sizes,
           this.state.tagId)
           .setTargeting('resp_mpu_inline_ad', 'refresh')
-          .addService(googleTag.pubads());
-        if (this.props.sizes && this.props.sizes.length > 1) {
-          slot.defineSizeMapping(mappingAd);
-        }
+          .addService(googleTag.pubads())
+          .defineSizeMapping(sizeMapping);
         googleTag.pubads().enableSingleRequest();
         googleTag.enableServices();
         googleTag.display(this.state.tagId);

--- a/index.es6
+++ b/index.es6
@@ -13,6 +13,11 @@ export default class AdPanel extends React.Component {
       lazyLoadMargin: React.PropTypes.number,
       sizes: React.PropTypes.arrayOf(React.PropTypes.array),
       sizeMapping: React.PropTypes.arrayOf(React.PropTypes.array),
+      targeting: React.PropTypes.arrayOf(
+        React.PropTypes.arrayOf(
+          React.PropTypes.string
+        )
+      ),
       reserveHeight: React.PropTypes.number,
       styled: React.PropTypes.bool,
     };
@@ -28,6 +33,7 @@ export default class AdPanel extends React.Component {
         [[980, 200], [[1024, 768]]],
         [[0, 0], [[300, 250]]],
       ],
+      targeting: [],
       styled: true,
     };
   }
@@ -110,13 +116,16 @@ export default class AdPanel extends React.Component {
       const googleTag = window.googletag;
       googleTag.cmd.push(() => {
         const sizeMapping = this.buildSizeMapping();
-        const slot = googleTag.defineSlot(
+        let slot = googleTag.defineSlot(
           this.props.adTag,
           this.props.sizes,
           this.state.tagId)
-          .setTargeting('resp_mpu_inline_ad', 'refresh')
           .addService(googleTag.pubads())
           .defineSizeMapping(sizeMapping);
+
+        for (const [ key, value ] of this.props.targeting) {
+          slot.setTargeting(key, value)
+        }
         googleTag.pubads().enableSingleRequest();
         googleTag.enableServices();
         googleTag.display(this.state.tagId);


### PR DESCRIPTION
This enables usage of googletag.sizemapping() from the outside of the tag, without actually loading the google ad tag.