### PR TITLE
Call collapseEmptyDivs

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -145,6 +145,7 @@ export default class AdPanel extends React.Component {
           slot.setTargeting(key, value)
         }
         googleTag.pubads().enableSingleRequest();
+        googleTag.pubads().collapseEmptyDivs();
         googleTag.enableServices();
         googleTag.display(this.state.tagId);
       });

--- a/index.es6
+++ b/index.es6
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -120,8 +119,9 @@ export default class AdPanel extends React.Component {
   buildSizeMapping() {
     let mapping = this.props.sizeMapping || [];
     const googleTag = this.getOrCreateGoogleTag();
-    assert(googleTag.sizeMapping,
-           'buildSizeMapping() must be called inside a googletag.cmd.push()\'ed function!');
+    if (!googleTag.sizeMapping) {
+      throw new Error('buildSizeMapping() must be called inside a googletag.cmd.push()\'ed function!');
+    }
     const sizeMappingBuilder = googleTag.sizeMapping();
     return mapping.reduce((builder, [viewportSize, adSizes]) => {
       return builder.addSize(viewportSize, adSizes)

--- a/index.es6
+++ b/index.es6
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -118,7 +119,10 @@ export default class AdPanel extends React.Component {
 
   buildSizeMapping() {
     let mapping = this.props.sizeMapping || [];
-    const sizeMappingBuilder = this.getOrCreateGoogleTag().sizeMapping();
+    const googleTag = this.getOrCreateGoogleTag();
+    assert(googleTag.sizeMapping,
+           'buildSizeMapping() must be called inside a googletag.cmd.push()\'ed function!');
+    const sizeMappingBuilder = googleTag.sizeMapping();
     return mapping.reduce((builder, [viewportSize, adSizes]) => {
       return builder.addSize(viewportSize, adSizes)
     }, sizeMappingBuilder).build();

--- a/test/index.es6
+++ b/test/index.es6
@@ -77,6 +77,7 @@ describe('AdPanel', () => {
     let sizeMappingBuilder;
     let adSlot;
     let fakeMapping;
+    let fakePubAds;
     beforeEach(() => {
       // These tests actually want to call generateAd
       instance.generateAd = chai.spy(AdPanel.prototype.generateAd);
@@ -107,10 +108,16 @@ describe('AdPanel', () => {
       chai.spy.on(adSlot, 'addService');
       chai.spy.on(adSlot, 'defineSizeMapping');
       chai.spy.on(adSlot, 'setTargeting');
+      fakePubAds = {
+        enableSingleRequest: () => null,
+        collapseEmptyDivs: () => null
+      };
+      chai.spy.on(fakePubAds, 'enableSingleRequest');
+      chai.spy.on(fakePubAds, 'collapseEmptyDivs');
       instance.props.googletag = {
         sizeMapping: () => sizeMappingBuilder,
         defineSlot: () => adSlot,
-        pubads: () => ({ enableSingleRequest: () => null }),
+        pubads: () => fakePubAds,
         enableServices: () => null,
         display: () => null,
         cmd: {
@@ -148,6 +155,8 @@ describe('AdPanel', () => {
       adSlot.setTargeting.should.have.been.called.with(
         'baz', 'qux'
       );
+      fakePubAds.enableSingleRequest.should.have.been.called();
+      fakePubAds.collapseEmptyDivs.should.have.been.called();
     });
   });
 


### PR DESCRIPTION
And also address @keithamus's concern that buildSizeMapping might be called before googletag is ready by asserting that the function is around so that nobody calls buildSizeMapping before that.