### PR TITLE
Turn "Advertisement" into CSS-rendered ::before of the google's ad panel.

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,6 +3,7 @@
 
 :root {
   --ad-left-strip-width: 5px;
+  --ad-panel-title-size: 1.7em;
 }
 
 .ad-panel__container {
@@ -11,25 +12,29 @@
   display: inline-block;
 }
 
-.ad-panel__container--styled .ad-panel__title,
+.ad-panel__container--styled .ad-panel__googlead::before,
 .ad-panel__container--styled .ad-panel__googlead {
   background-color: var(--color-berlin);
 }
 
 .ad-panel__container--styled .ad-panel__googlead {
   padding-left: var(--ad-left-strip-width);
+  margin-top: var(--ad-panel-title-size);
 }
-.ad-panel__container--styled .ad-panel__title {
+.ad-panel__container--styled .ad-panel__googlead::before {
+  content: 'Advertisement';
+  content: attr(title);
   padding: var(--ad-left-strip-width);
   border-top-right-radius: calc(var(--ad-left-strip-width) / 2);
   border-top-left-radius: calc(var(--ad-left-strip-width) / 2);
-}
-
-.ad-panel__container--styled .ad-panel__title {
   color: var(--color-london);
   font-family: var(--fontfamily-body);
   font-size: var(--text-size-step--1);
   line-height: var(--text-line-height-body-on-step--1);
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
 }
 
 .ad-panel__container iframe,

--- a/index.css
+++ b/index.css
@@ -22,7 +22,6 @@
   margin-top: var(--ad-panel-title-size);
 }
 .ad-panel__container--styled .ad-panel__googlead::before {
-  content: 'Advertisement';
   content: attr(title);
   padding: var(--ad-left-strip-width);
   border-top-right-radius: calc(var(--ad-left-strip-width) / 2);

--- a/index.es6
+++ b/index.es6
@@ -193,13 +193,11 @@ export default class AdPanel extends React.Component {
       if (this.props.reserveHeight) {
         adStyle = { minHeight: this.props.reserveHeight };
       }
-      tag = (<div className="ad-panel__googlead" id={this.state.tagId} style={adStyle}></div>);
+      tag = (<div className="ad-panel__googlead" id={this.state.tagId} style={adStyle} title="Advertisement"></div>);
     }
     let rootClassNames = [ 'ad-panel__container' ];
-    let title = [];
     if (this.props.styled) {
       rootClassNames = rootClassNames.concat([ 'ad-panel__container--styled' ]);
-      title = (<span ref="title" className="ad-panel__title">Advertisement</span>);
     }
     if (this.props.animated) {
       rootClassNames = rootClassNames.concat([ 'ad-panel__animated' ]);
@@ -210,7 +208,6 @@ export default class AdPanel extends React.Component {
     };
     return (
       <div ref="container" className={rootClassNames.join(' ')} {...aria}>
-        {title}
         {tag}
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-ad-panel",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An advert panel using GPT tags",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
Sometimes, DFP doesn't communicate (using events) that their ad didn't load. Instead, it will collapse the DIV, and hide it. This causes "Advertisement" to float awkwardly on the page.

This puts the word "Advertisement" in an attribute, that is then read using css's `attr()`.