### PR TITLE
Fixes crashing tests.

### DIFF
--- a/test/index.es6
+++ b/test/index.es6
@@ -97,7 +97,7 @@ describe('AdPanel', () => {
         [ 'foo', 'bar' ],
         [ 'baz', 'qux' ],
       ];
-      fakeMapping = Symbol('fakemapping');
+      fakeMapping = {};  // <- Just for reference equality. Not a symbol because it crashes on IE and Safari.
       sizeMappingBuilder = {
         addSize() {
           return this;


### PR DESCRIPTION
Usage of Symbol was crashing tests in IE, safari and mobile safari!

This removes it and exchanges it with an old-timer style object.