### PR TITLE
Create full width ad panel class #TEC-510

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -43,6 +43,22 @@ export default (
         mel no viderer inermis concludaturque. Ea eum omnis propriae, ea justo doming mediocrem pri. Nam eu paulo
          platonem pertinacia. Everti scripta pro ne, est an oratio euismod.</p>
 
+       <AdPanel adTag="/5605/teg.fmsq/wdif/busi"
+       sizes={[ [ 300, 250 ] ]}
+       block={true}
+       targeting={
+         [
+           [ 'pos', 'something' ],
+           [ 'other_key', 'something_else' ],
+         ]
+       }
+       sizeMapping={
+         [
+           [ [ 1024, 768 ], [ [ 300, 250 ] ] ],
+         ]
+       }
+       reserveHeight={250} />
+
       <p>No cum omnis epicurei, an elitr ludus qualisque cum. Ludus alienum iudicabit id qui. Convenire incorrupte
        reprehendunt id eum. Solum clita quo id. Nisl sale inimicus ea sea, per quem timeam tamquam ad.</p>
 
@@ -90,6 +106,7 @@ export default (
     </div>
     <AdPanel adTag="/5605/teg.fmsq/wdif/busi"
     sizes={[ [ 300, 250 ] ]}
+    styled={true}
     targeting={
       [
         [ 'pos', 'something' ],

--- a/index.css
+++ b/index.css
@@ -21,19 +21,39 @@
   padding-left: var(--ad-left-strip-width);
   margin-top: var(--ad-panel-title-size);
 }
+
 .ad-panel__container--styled .ad-panel__googlead::before {
   content: attr(title);
   padding: var(--ad-left-strip-width);
   border-top-right-radius: calc(var(--ad-left-strip-width) / 2);
   border-top-left-radius: calc(var(--ad-left-strip-width) / 2);
   color: var(--color-london);
-  font-family: var(--fontfamily-body);
-  font-size: var(--text-size-step--1);
-  line-height: var(--text-line-height-body-on-step--1);
+  font-family: var(--ad-panel-fontfamily, var(--fontfamily-sans));
+  font-size: var(--ad-panel-text-size-step, var(--text-size-step--3));
+  line-height:  var(--ad-panel-line-height, 2);
   position: absolute;
   top: 0;
   left: 0;
   z-index: -1;
+}
+
+.ad-panel__container--block {
+  display: block;
+}
+
+.ad-panel__container--block .ad-panel__googlead::before,
+.ad-panel__container--block .ad-panel__googlead {
+  background-color: var(--color-berlin);
+}
+
+.ad-panel__container--block .ad-panel__googlead::before {
+  position:inherit;
+  line-height:  var(--ad-panel-line-height, 2.5);
+}
+
+.ad-panel__container--block .ad-panel__googlead {
+  padding-top:0.35em;
+  padding-bottom:2em;
 }
 
 .ad-panel__container iframe,

--- a/index.es6
+++ b/index.es6
@@ -22,6 +22,7 @@ export default class AdPanel extends React.Component {
       ),
       reserveHeight: React.PropTypes.number,
       styled: React.PropTypes.bool,
+      block: React.PropTypes.bool,
       googletag: React.PropTypes.object,  // Testing hook
     };
   }
@@ -203,6 +204,9 @@ export default class AdPanel extends React.Component {
     let rootClassNames = [ 'ad-panel__container' ];
     if (this.props.styled) {
       rootClassNames = rootClassNames.concat([ 'ad-panel__container--styled' ]);
+    }
+    if (this.props.block) {
+      rootClassNames = rootClassNames.concat([ 'ad-panel__container--block' ]);
     }
     if (this.props.animated) {
       rootClassNames = rootClassNames.concat([ 'ad-panel__animated' ]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-ad-panel",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "An advert panel using GPT tags",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "@economist/component-palette": "^1.2.1",
-    "@economist/component-typography": "^1.4.3",
+    "@economist/component-typography": "^2.0.0",
     "react-dom": "^0.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
1. .ad-panel__container class has a new property called --block. You can use this property to call up a full width ad panel. This approach was decided against media queries because ad-panel component has its "special" behaviour.
2. :before label font uses the latest component-typography dependency.
3. The changes made were breaking changes so package.json version bumped to major.


