### PR TITLE
Remove outstanding margin-top and padding-left

### DIFF
--- a/index.css
+++ b/index.css
@@ -56,6 +56,11 @@
   padding-bottom:2em;
 }
 
+.ad-panel__container--block .ad-panel__googlead {
+  padding-left: 0;
+  margin-top: 0;
+}
+
 .ad-panel__container iframe,
 .ad-panel__container img{
   margin: 0 auto;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-ad-panel",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An advert panel using GPT tags",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
There was some spacing added to the top, due to the fact that the `::before` was sitting outside of the box model and needed some space so as to not appear on top of anything else. Also, padding-left was added to create a rim.

This doesn't make sense when the ad is a block, so this pull request removes it when that is the case!