### PR TITLE
fix: Hide visible wrapper when ads don't render inside the container

### DIFF
--- a/index.css
+++ b/index.css
@@ -12,6 +12,11 @@
   display: inline-block;
 }
 
+/* Don'r render the "Advertisement" text when the ad loads nothing into the panel */
+.ad-panel__container--styled .ad-panel__googlead:empty {
+  display: none;
+}
+
 .ad-panel__container--styled .ad-panel__googlead::before,
 .ad-panel__container--styled .ad-panel__googlead {
   background-color: var(--color-berlin);


### PR DESCRIPTION
When an ad is loaded just for its side-effect (EG: an ad showing up in the middle of an article, or just to track something) the visible container should be hidden. This avoids an awkward gray rim and the word "Advertisement" showing up on the page.