### PR TITLE
feat: Allow for ad-related props to be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,8 @@ For more examples on usage, see [`src/example.es6`](./src/example.es6).
 
 ## Props and defaults:
 
- * `animated={true}` (boolean): when the ad enters the screen, it animates upwards.
  * `adTag` (required string): The DFP tag this points to. Often in the format of a URL. example: `/5605/foo.bar/qux/x`.
  * `className` (string): Add this className to ad-panel__container.
- * `lazyLoad={true}` (boolean): Don't load the ad until it's close to the screen.
- * `lazyLoadMargin={350}` (number of px): How close to the screen does the ad need to be to be loaded by `lazyLoad`.
  * ```
   sizes={[
       [ 60, 60 ],

--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ The `lazyload` prop has been removed as the feature was making this component un
 </LazyLoad>
 ```
 
+The `animated` prop has also been removed, and its relevant CSS with it. This feature can also be implemented very easily using LazyLoad (and some classNames):
+
+```
+// Before:
+<AdPanel animated {...otherProps} />
+
+// After:
+class AnimatedAd extends React.Component {
+  render() {
+    const className = this.state && this.state.visible ?
+      'animated-ad-wrapper animated-ad-wrapper--visible' :
+      'animated-ad-wrapper';
+    return (
+      <div className={className}>
+        <LazyLoad onContentVisible={() => { this.setState({ visible: true }) }}>
+          <AdPanel {...this.props} />
+        </LazyLoad>
+      </div>
+    )
+  }
+}
+<AnimatedAd {...otherProps} />
+```
+
 Both work exactly the same.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ For more examples on usage, see [`src/example.es6`](./src/example.es6).
  * [understanding sizeMappings](https://support.google.com/dfp_premium/answer/3423562)
 
 
+## Deprecation notice
+
+The `lazyload` prop has been removed as the feature was making this component unmaintainable and bug-prone. From now on you can use the excellent [react-lazy-load](https://github.com/loktar00/react-lazy-load/). Here's an example:
+
+```
+// Before:
+<AdPanel lazyLoad {...otherProps} />
+
+// After:
+<LazyLoad>
+  <AdPanel {...otherProps} />
+</LazyLoad>
+```
+
+Both work exactly the same.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
   "dependencies": {
     "@economist/component-palette": "^1.2.1",
     "@economist/component-typography": "^3.1.1",
-    "lodash.values": "^4.1.0",
     "react": "^0.14.8||^15.0.0",
     "react-dom": "^0.14.8||^15.0.0"
   },

--- a/src/index.css
+++ b/src/index.css
@@ -64,14 +64,3 @@
 
 /* stylelint-enable selector-no-type */
 
-.ad-panel__animated {
-  opacity: 0;
-  transform: translateY(100px);
-  transition: all 0.4s ease-out 0.5s;
-  transition-property: opacity, transform;
-}
-
-.ad-panel__animated.ad-panel--visible {
-  opacity: 1;
-  transform: translateY(0);
-}


### PR DESCRIPTION
 *    BREAKING CHANGE: "animated" and "lazyLoad" props have been deprecated
 *    BREAKING CHANGE: sizes and sizeMappings defaults have been removed

This allows for an AdPanel's adTag to be changed during runtime. Previously, changing the adTag had no effect.

This also decimates some old stuff which was not working anyways.