### PR TITLE
fix: TEC-1198: using googleTag.refresh to handle incremental updates

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ function createFakeGoogleTag() {
     setTargeting: chai.spy(() => slotApi),
   };
   const pubadsApi = {
+    disableInitialLoad: chai.spy(() => null),
     enableSingleRequest: chai.spy(() => null),
     collapseEmptyDivs: chai.spy(() => null),
     addEventListener: chai.spy(),
@@ -51,7 +52,7 @@ describe('AdPanel', () => {
   });
 
   it('renders a React element', () => {
-    React.isValidElement(<AdPanel />).should.equal(true);
+    React.isValidElement(<AdPanel adTag="foo" />).should.equal(true);
   });
 
   describe('Rendering', () => {
@@ -120,6 +121,22 @@ describe('AdPanel', () => {
           [ 'baz', 'qux' ],
         ];
         googleTag = createFakeGoogleTag();
+      });
+
+      it('disable initial loading to allow for incremental loading of ads', () => {
+        AdPanel.config(
+          {
+            sra: true,
+            targeting: {
+              etear: 'etear',
+              subscriber: 'subscriber',
+            },
+          }
+        );
+        googleTag.cmd.forEach((callback) => callback());
+        const pubAds = googleTag.pubads();
+        pubAds.disableInitialLoad.should.have.been.called();
+        pubAds.enableSingleRequest.should.have.been.called();
       });
 
       it('uses the googletag API to add sizes and targeting options', () => {


### PR DESCRIPTION
In order to correctly implement incremental updates of the Ads (that means, to show more of them every time we paginate with the 'Load more' button) we need to change the way we use SRA. 
Just calling 'enableSingleRequest' won't cut it, since it requires ALL the slots to be already defined before making the call. This is not the case with pagination (since we create new ones every time we paginate).
Google has a scenario for this (what they call 'infinite content' pages). In short: it consists in disabling the initial load that would normally happen when calling 'enableSingleRequest' and instead call 'refresh([slots])' when we want to retrieve the Ads content. 
This is what this change is all about.