### PR TITLE
fix: When updating the ad tag, change the element's ID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,18 +122,8 @@ export default class AdPanel extends React.Component {
     this.unlistenSlotRenderEnded = () => null;
   }
 
-  componentWillMount() {
-    this.setState({
-      tagId: `googlead-${ uniqueId() }`,
-      adGenerated: false,
-      adFailed: false,
-    });
-  }
-
   componentDidMount() {
-    if (this.state && this.state.tagId) {
-      this.generateAd();
-    }
+    this.generateAd();
   }
 
   componentWillUpdate(nextProps) {
@@ -245,10 +235,18 @@ export default class AdPanel extends React.Component {
         }
       }
     });
-    this.setState({ adGenerated: true });
   }
 
   defineSlot(googleTag) {
+    this.setState({
+      tagId: `googlead-${ uniqueId() }`,
+      adFailed: false,
+    }, () => {
+      this.onTagIDUpdated(googleTag);
+    });
+  }
+
+  onTagIDUpdated(googleTag) {
     const sizeMapping = this.buildSizeMapping();
     const { adTag, sizes } = this.props;
     const { tagId } = this.state;
@@ -282,21 +280,18 @@ export default class AdPanel extends React.Component {
     if (this.state && this.state.adFailed) {
       return (<div />);
     }
-    let tag = [];
-    if (this.state && this.state.tagId) {
-      let adStyle = {};
-      if (this.props.reserveHeight) {
-        adStyle = { minHeight: this.props.reserveHeight };
-      }
-      tag = (
-        <div
-          className="ad-panel__googlead"
-          id={this.state.tagId}
-          style={adStyle}
-          title="Advertisement"
-        ></div>
-      );
+    let adStyle = {};
+    if (this.props.reserveHeight) {
+      adStyle = { minHeight: this.props.reserveHeight };
     }
+    const tag = (
+      <div
+        className="ad-panel__googlead"
+        id={this.state && this.state.tagId}
+        style={adStyle}
+        title="Advertisement"
+      ></div>
+    );
     let rootClassNames = [ 'ad-panel__container' ];
     if (this.props.styled) {
       rootClassNames = rootClassNames.concat([ 'ad-panel__container--styled' ]);

--- a/test/index.js
+++ b/test/index.js
@@ -68,22 +68,9 @@ describe('AdPanel', () => {
 
     it('ad is generated once mounted', () => {
       rendered.setState({ tagId: true });
-      rendered.should.have.state('adGenerated', true);
       googleTag.cmd.should.have.lengthOf(1)
         .and.have.property(0).that.is.a('function');
     });
-
-    describe('after ad generation', () => {
-
-      it('ad is generated once mounted', () => {
-        rendered.setState({ tagId: true });
-        rendered.should.have.state('adGenerated', true);
-        googleTag.cmd.should.have.lengthOf(1)
-          .and.have.property(0).that.is.a('function');
-      });
-
-    });
-
   });
 
   describe('lifecycle methods', () => {
@@ -149,11 +136,8 @@ describe('AdPanel', () => {
             },
           }
         );
-        instance.generateAd();
-        instance.setState.should.have.been.called.with({ adGenerated: true });
-        googleTag.cmd.should.have.lengthOf(2);
-        googleTag.cmd.forEach((callback) => callback());
         const sizeMapping = googleTag.sizeMapping();
+        instance.onTagIDUpdated(googleTag);
         sizeMapping.addSize.should.have.been.called.with([ 800, 600 ], [ [ 300, 250 ] ]);
         sizeMapping.build.should.have.been.called();
         const adSlot = googleTag.defineSlot();
@@ -162,15 +146,11 @@ describe('AdPanel', () => {
         adSlot.setTargeting.should.have.been.called.with('baz', 'qux');
         const pubAds = googleTag.pubads();
         pubAds.setTargeting.should.have.been.called.exactly(2);
-        pubAds.enableSingleRequest.should.have.been.called();
-        pubAds.collapseEmptyDivs.should.have.been.called();
       });
 
       it('binds props.onImpressionViewable to impressionViewable if available', () => {
         const onImpressionViewable = instance.props.onImpressionViewable = chai.spy();
-        instance.generateAd();
-        googleTag.cmd.should.have.lengthOf(1);
-        googleTag.cmd.forEach((callback) => callback());
+        instance.onTagIDUpdated(googleTag);
         googleTag.pubads().addEventListener
           .should.have.been.called.at.least(1)
           .with('impressionViewable', onImpressionViewable);
@@ -178,9 +158,7 @@ describe('AdPanel', () => {
 
       it('binds props.onSlotVisibilityChanged to slotVisibilityChanged if available', () => {
         const onSlotVisibilityChanged = instance.props.onSlotVisibilityChanged = chai.spy();
-        instance.generateAd();
-        googleTag.cmd.should.have.lengthOf(1);
-        googleTag.cmd.forEach((callback) => callback());
+        instance.onTagIDUpdated(googleTag);
         googleTag.pubads().addEventListener
           .should.have.been.called.at.least(1)
           .with('slotVisibilityChanged', onSlotVisibilityChanged);
@@ -191,12 +169,8 @@ describe('AdPanel', () => {
         let slotRenderEndedEventListener = null;
         let slotData = null;
         beforeEach(() => {
-          instance.generateAd();
-          googleTag.cmd.should.have.lengthOf(1);
-          googleTag.cmd.forEach((callback) => callback());
+          instance.onTagIDUpdated(googleTag);
           pubAds = googleTag.pubads();
-          googleTag.cmd.should.have.lengthOf(1);
-          googleTag.cmd.forEach((callback) => callback());
           chai.spy.on(instance, 'unlistenSlotRenderEnded');
           chai.spy.on(instance, 'cleanupEventListeners');
           slotRenderEndedEventListener = getSpyCall(pubAds.addEventListener, 0)[1];


### PR DESCRIPTION
It looks like destroying the slot and immediately using it after without changing the ID makes google not put an ad there.