### PR TITLE
fix: Avoiding common mistakes in GPT implementation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,16 +104,20 @@ export default class AdPanel extends React.Component {
     if (typeof window === 'undefined' || typeof window.document === 'undefined') {
       return null;
     }
-    if (window.googletag) {
-      return window.googletag;
+    window.gptScriptInserted = window.gptScriptInserted || false;
+    window.googletag = window.googletag || {};
+    const googletag = window.googletag;
+    if (googletag.apiReady || window.gptScriptInserted) {
+      return googletag;
     }
-    window.googletag = { cmd: [] };
+    googletag.cmd = googletag.cmd || [];
     const gads = document.createElement('script');
     gads.async = true;
     gads.type = 'text/javascript';
     const useSsl = window.location.protocol === 'https:';
     gads.src = `${ useSsl ? 'https:' : 'http:' }//www.googletagservices.com/tag/js/gpt.js`;
     window.document.head.appendChild(gads);
+    window.gptScriptInserted = true;
     return window.googletag;
   }
 


### PR DESCRIPTION
In support of: https://jira.economist.com/browse/WP-524

Ad panel now does not assume `window.googletag` has not been defined but deals with the situation when it already has been initialized (by some other code or component).
https://developers.google.com/doubleclick-gpt/common_implementation_mistakes

It uses `googletag.apiReady` to check whether the GPT script is loaded and global variable to cover the state after script was inserted and api is not ready yet - to prevent having double <script> in the document.

Note that I need this update to the component available for the PR on E.com.
https://github.com/EconomistDigitalSolutions/fe-blogs/pull/836